### PR TITLE
ontology extender 

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,19 +1,22 @@
-odinson.indexDir = "path/to/index" // the index will be saved here when using IndexCDRs and reac from here while using Taxero
-odinson.dataDir = "path/to/data/dir"
-apps.cdrDir = "path/to/cdr/files"
+odinson.indexDir = "/local/path/to/index" // the index will be saved here when using IndexCDRs and read from here while using Taxero
+odinson.dataDir = "/local/path/to/data/dir"
+apps.cdrDir = "/local/path/to/dir/containing/cdrs/for/indexing"
 
 taxero {
-  wordEmbeddings = "path/to/vectors.txt"
+  wordEmbeddings = "/local/path/to/vectors.txt"
   lemmatize = true
 }
 
 ontologyExtender {
-  ontologyDir = "path/to/ontology/leaf/files"
-  outputDir = "path/to/ontologyFilesEnriched"
+  ontologyDir = "/local/path/to/ontology/files"
+  outputDir = ""
   manualEval = false // true to output files that can be used for manual eval of the extender ouputs
-  similarityToHeaderTreshold = 1.16 // might need tuning
+  similarityToHeaderTreshold = 1.16  // best for current decaying similarity to header score
+  addExamplesProportionallyToCurrentNum = false
+  proportionToExpandBy = 0.5
   maxExamplesToAddPerOntologyLeaf = 10
   inclOriginalLeaf = true
   onlyQueryByLeafHeaderTerms = false
   lemmatize = true
+  countThreshold = 0 // example has to occur at least countThreshold times to be added to ontology
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -11,7 +11,7 @@ ontologyExtender {
   ontologyDir = "path/to/ontology/leaf/files"
   outputDir = "path/to/ontologyFilesEnriched"
   manualEval = false // true to output files that can be used for manual eval of the extender ouputs
-  similarityToHeaderTreshold = 0.75
+  similarityToHeaderTreshold = 1.16 // might need tuning
   maxExamplesToAddPerOntologyLeaf = 10
   inclOriginalLeaf = true
   onlyQueryByLeafHeaderTerms = false

--- a/src/main/scala/org/clulab/taxero/OntologyExtender.scala
+++ b/src/main/scala/org/clulab/taxero/OntologyExtender.scala
@@ -139,6 +139,7 @@ object OntologyExtender extends App with LazyLogging {
   }
 
   def isSimilarToLeafHeader(result: ScoredMatch, header: Seq[String], similarityToHeaderTreshold: Double): Boolean = {
+    // todo: When calculating the embedding for the name/header of the leaf, add decay, that is decrease the weight of the nodes on the path as we move up the ontology (decrease node weight by, for example, half every step up the ontology)
     reader.similarityScore(result.result.map(_.toLowerCase()), header) > similarityToHeaderTreshold
   }
 


### PR DESCRIPTION
updated the ontology extender with a number of filters incl similarity of taxero results to the header, counter training (whether or not the token to be added as an example exists in other leaves), only adding results that are seen more than n times, etc. In manual eval mode, outputs full taxero results, inlc. collocations, otherwise, only writes distinct tokens from the results, with some of the filters applied right before writing to file. 